### PR TITLE
spring-cloud-consul: 1.2.1.BUILD-SNAPSHOT -> 2.0.0.BUILD-SNAPSHOT

### DIFF
--- a/spring-cloud-dependencies/pom.xml
+++ b/spring-cloud-dependencies/pom.xml
@@ -21,7 +21,7 @@
 		<spring-cloud-cloudfoundry.version>1.1.1.BUILD-SNAPSHOT</spring-cloud-cloudfoundry.version>
 		<spring-cloud-commons.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-config.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-config.version>
-		<spring-cloud-consul.version>1.2.1.BUILD-SNAPSHOT</spring-cloud-consul.version>
+		<spring-cloud-consul.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-consul.version>
 		<spring-cloud-gateway.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-gateway.version>
 		<spring-cloud-netflix.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<spring-cloud-security.version>1.2.1.BUILD-SNAPSHOT</spring-cloud-security.version>


### PR DESCRIPTION
`spring-cloud-consul:1.2.1.BUILD-SNAPSHOT` can't be used together with `spring-boot:2.0.0.M1` as it uses `org/springframework/boot/bind/RelaxedPropertyResolver` which has been gone ( https://github.com/spring-projects/spring-boot/commit/4e3d280378791e91d91720537cf3279f5f48b37c ).  