### PR TITLE
Restore PDF production

### DIFF
--- a/train-docs/src/main/resources/templates/spring-cloud/spring-cloud-pdf.hbs
+++ b/train-docs/src/main/resources/templates/spring-cloud/spring-cloud-pdf.hbs
@@ -1,0 +1,57 @@
+= Spring Cloud
+
+include::_attributes.adoc[]
+include::_spring-cloud-attributes.adoc[]
+
+:basedir: {project-root}
+:project-full-name: Spring Cloud
+:project-name: spring-cloud
+
+Spring Cloud provides tools for developers to quickly build some of
+the common patterns in distributed systems (e.g. configuration
+management, service discovery, circuit breakers, intelligent routing,
+micro-proxy, control bus). Coordination of
+distributed systems leads to boiler plate patterns, and using Spring
+Cloud developers can quickly stand up services and applications that
+implement those patterns. They will work well in any distributed
+environment, including the developer's own laptop, bare metal data
+centres, and managed platforms such as Cloud Foundry.
+
+Release Train Version: *{spring-cloud-version}*
+
+Supported Boot Version: *{spring-boot-version}*
+
+== Features
+
+Spring Cloud focuses on providing good out of box experience for typical use cases
+and extensibility mechanism to cover others.
+
+* Distributed/versioned configuration
+* Service registration and discovery
+* Routing
+* Service-to-service calls
+* Load balancing
+* Circuit Breakers
+* Distributed messaging
+
+[[cloud-documentation-versions]]
+== Release Train Versions
+
+.Release Train Project Versions
+|===
+|Project Name| Project Version
+
+include::_spring-cloud-versions.adoc[]
+|===
+
+{{=<% %>=}}
+<%#each springCloudProjects%>
+:project-root: {basedir}/<%name%>
+:project-version: {<%name%>-version}
+include::<%include%>
+<%/each%>
+<%={{ }}=%>
+
+= Appendix: Compendium of Configuration Properties
+
+include::configprops.adoc[leveloffset=+1]


### PR DESCRIPTION
Restore train-docs/src/main/resources/templates/spring-cloud/spring-cloud-pdf.hbs

so that we get PDF production. See
https://github.com/spring-cloud/spring-cloud-kubernetes/pull/693

The bad table definition was causing the CannotFit error.